### PR TITLE
Remove coc install redundancy

### DIFF
--- a/02-coc.sh
+++ b/02-coc.sh
@@ -1,2 +1,2 @@
 # Install all language support
-nvim -c "CocInstall coc-clangd coc-rust-analyzer coc-jedi coc-json coc-jedi"
+nvim -c "CocInstall coc-clangd coc-rust-analyzer coc-jedi coc-json"


### PR DESCRIPTION
There are two coc-jedi in the script. I don't know why but I remove it and it works well.